### PR TITLE
Removed alt radio mapping on .

### DIFF
--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -12,7 +12,7 @@ public abstract class SharedChatSystem : EntitySystem
 {
     public const char RadioCommonPrefix = ';';
     public const char RadioChannelPrefix = ':';
-    public const char RadioChannelAltPrefix = '.';
+//    public const char RadioChannelAltPrefix = '¨'; //Scav: Removed RadioChannelAltPrefix
     public const char LocalPrefix = '>';
     public const char ConsolePrefix = '/';
     public const char DeadPrefix = '\\';
@@ -103,7 +103,7 @@ public abstract class SharedChatSystem : EntitySystem
         if (input.Length <= 2)
             return;
 
-        if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
+        if (!input.StartsWith(RadioChannelPrefix)) //Scav: removed RadioChannelAltPrefix
             return;
 
         if (!_keyCodes.TryGetValue(char.ToLower(input[1]), out _))
@@ -143,7 +143,7 @@ public abstract class SharedChatSystem : EntitySystem
             return true;
         }
 
-        if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
+        if (!input.StartsWith(RadioChannelPrefix)) //Scav: removed RadioChannelAltPrefix
             return false;
 
         if (input.Length < 2 || char.IsWhiteSpace(input[1]))


### PR DESCRIPTION
## About the PR
Removed alt radio mapping on "."

## Why / Balance
Having "." map to radio made it annoying to start a chat message with an ellipsis. This fixes that.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
Try typing a . in local chat. Observe that it no longer switches your chat channel to radio

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
Commented out or deleted all references to RadioChannelAltPrefix from Content.Shared\Chat\SharedChatSystem.cs
This is currently only used within this file but may cause issues if any upstream updates reference it.

**Changelog**
- remove: Removed the second radio channel prefix due to an inconvenient mapping
