### PR TITLE
Adjusted yinglets temperature regulation

### DIFF
--- a/Resources/Prototypes/_Scav/Entities/Mobs/Species/yinglet.yml
+++ b/Resources/Prototypes/_Scav/Entities/Mobs/Species/yinglet.yml
@@ -90,21 +90,21 @@
         damage: 200
       behaviors:
       - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 800
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+    # - trigger: # Scav: removed to match frontier's handling of
+    #     !type:DamageTypeTrigger
+    #     damageType: Heat
+    #     damage: 800
+    #   behaviors:
+    #   - !type:SpawnEntitiesBehavior
+    #     spawnInContainer: true
+    #     spawn:
+    #       Ash:
+    #         min: 1
+    #         max: 1
+    #   - !type:BurnBodyBehavior { }
+    #   - !type:PlaySoundBehavior
+    #     sound:
+    #       collection: MeatLaserImpact
   - type: MeleeWeapon
     soundHit:
       collection: BarestepWood
@@ -129,7 +129,14 @@
   - type: MovementSpeedModifier
     basewalkspeed: 4
     basesprintspeed: 6
-#at some point maybe add body heat differences from humans but its fine for now
+  - type: ThermalRegulator #Yinglets have about 1/7 the mass of humans so these need to change
+    metabolismHeat: 400
+    radiatedHeat: 50
+    implicitHeatRegulation: 150
+    sweatHeatRegulation: 250
+    shiveringHeatRegulation: 250
+    normalBodyTemperature: 310.15 #may want a higher body temperature than humans eventually but this is fine for now
+    thermalRegulationTemperatureThreshold: 2
   - type: Sprite #some layers need reordering
     size: 0.8, 0.8
     layers:


### PR DESCRIPTION
## About the PR
Adjusted yinglets temperature regulation so cryo pods work on them, removed gibbing from heat damage for parity with the rest of Frontier

## Why / Balance
Due to an oversight, yinglets didnt get cold properly and cryo didnt work on them, this fixes that

## Technical details
yaml, particularly changes to the parameters of the ThermalRegulator component for yinglets due to their lower mass

## How to test
Put a yinglet in a cryo tube, observe that they now get cold a bit faster than humans, and cap out at roughly the same temperature

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
:cl:
- tweak: gave yinglets non-default thermal regulation to suit their lower mass
- remove: removed yinglets gibbing from heat damage, for parity with the rest of Frontier
