### PR TITLE
Added new ivenmoth vouchers for medical and expedition ships

### DIFF
--- a/Resources/Prototypes/_Scav/Entities/Objects/Devices/Misc/ship_vouchers.yml
+++ b/Resources/Prototypes/_Scav/Entities/Objects/Devices/Misc/ship_vouchers.yml
@@ -37,7 +37,7 @@
 - type: entity
   parent: BaseShipVoucher
   id: ShipVoucherIvenmoth
-  name: Shipyard Voucher
+  name: Ivenmoth Shipyard Voucher
   description: Per the Tradehouse's arrangement with Nanotrasen, all Tradehouse employees are afforded a free ship purchase.
   components:
   - type: Sprite
@@ -50,5 +50,29 @@
   - type: ShipyardVoucher
     destroyOnEmpty: true
     consoleType: Shipyard
+    accessGroups:
+    - GeneralAccess
+
+- type: entity
+  parent: ShipVoucherIvenmoth
+  id: ShipVoucherIvenmothExpedition
+  name: Ivenmoth Expeditionary Shipyard Voucher
+  description: Per the Tradehouse's arrangement with Nanotrasen, all Tradehouse employees are afforded a free ship purchase.
+  components:
+  - type: ShipyardVoucher
+    destroyOnEmpty: true
+    consoleType: Expedition
+    accessGroups:
+    - GeneralAccess
+
+- type: entity
+  parent: ShipVoucherIvenmoth
+  id: ShipVoucherIvenmothMedical
+  name: Ivenmoth Medical Shipyard Voucher
+  description: Per the Tradehouse's arrangement with Nanotrasen, all Tradehouse employees are afforded a free ship purchase.
+  components:
+  - type: ShipyardVoucher
+    destroyOnEmpty: true
+    consoleType: Medical
     accessGroups:
     - GeneralAccess

--- a/Resources/Prototypes/_Scav/Loadouts/Jobs/IvenmothRecruit/backpack_items.yml
+++ b/Resources/Prototypes/_Scav/Loadouts/Jobs/IvenmothRecruit/backpack_items.yml
@@ -4,3 +4,18 @@
   storage:
     back:
     - ShipVoucherIvenmoth
+
+- type: loadout
+  id: IvenmothRecruitShipVoucherExpedition
+  price: 0
+  storage:
+    back:
+    - ShipVoucherIvenmothExpedition
+
+- type: loadout
+  id: IvenmothRecruitShipVoucherMedical
+  price: 0
+  storage:
+    back:
+    - ShipVoucherIvenmothMedical
+

--- a/Resources/Prototypes/_Scav/Loadouts/ivenmothrecruit_loadout_groups.yml
+++ b/Resources/Prototypes/_Scav/Loadouts/ivenmothrecruit_loadout_groups.yml
@@ -32,6 +32,8 @@
   maxLimit: 6
   loadouts:
     - IvenmothRecruitShipVoucher
+    - IvenmothRecruitShipVoucherExpedition
+    - IvenmothRecruitShipVoucherMedical
   subgroups:
     - ContractorBackpackItems
   fallbacks:


### PR DESCRIPTION
## About the PR
Added new ivenmoth vouchers, available in loadout

## Why / Balance
Want to make those other ships available to try out for ivenmoth players, this is easier than reworking the system to allow the normal voucher to work on multiple consoles

## Technical details
yaml

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.


**Changelog**
:cl:
- add: Added ivenmoth expeditionary and medical vouchers
- tweak: renamed normal ivenmoth voucher to not just be called "shipyard voucher"