### PR TITLE
Minorfixes

### DIFF
--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -24,7 +24,7 @@ public sealed class NFCCVars
     /// Respawn time, how long the player has to wait in seconds after death, or on subsequent cryo attempts.
     /// </summary>
     public static readonly CVarDef<float> RespawnTime =
-        CVarDef.Create("nf14.respawn.time", 1200.0f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.respawn.time", 900.0f, CVar.SERVER | CVar.REPLICATED); //Scav: 1200.0<900.0
 
     /// <summary>
     /// Whether or not returning from cryosleep is enabled.
@@ -105,10 +105,10 @@ public sealed class NFCCVars
         CVarDef.Create("shuttle.shipyard", true, CVar.SERVERONLY);
 
     /// <summary>
-    /// Base sell rate (multiplier: 0.75 = 75%)
+    /// Base sell rate (multiplier: 0.75 = 75%) #Scav: updated to 0.95
     /// </summary>
     public static readonly CVarDef<float> ShipyardSellRate =
-        CVarDef.Create("shuttle.shipyard_base_sell_rate", 0.75f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.shipyard_base_sell_rate", 0.95f, CVar.SERVERONLY);
 
     /*
      * Salvage
@@ -239,7 +239,7 @@ public sealed class NFCCVars
     ///     If true, allows map extraction (scrubbing a planet's atmosphere).
     /// </summary>
     public static readonly CVarDef<bool> AllowMapGasExtraction =
-        CVarDef.Create("nf14.atmos.allow_map_gas_extraction", false, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.atmos.allow_map_gas_extraction", true, CVar.SERVER | CVar.REPLICATED); //Scav: false<true
 
     /*
      * Audio

--- a/Resources/Locale/en-US/lobby/ui/observe-warning-window.ftl
+++ b/Resources/Locale/en-US/lobby/ui/observe-warning-window.ftl
@@ -1,7 +1,7 @@
 observe-nevermind = Nevermind
 observe-confirm = Observe
 observe-warning-1 = Are you sure you want to observe?
-observe-warning-2 = You cannot play in the round if you do so.
+observe-warning-2 = If you respawn, do not use any information learned while observing.
 observe-warning-window-title = Warning
 observe-as-admin = Admin Observe
 observe-as-player = Player Observe

--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -46,8 +46,8 @@
             Sheriff: [ 1, 1 ]
             Bailiff: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
-            Brigmedic: [ 0, 0 ]
-            NFDetective: [ 0, 0 ]
+            Brigmedic: [ 1, 1 ]
+            NFDetective: [ 1, 1 ]
             Deputy: [ 3, 3 ]
             Cadet: [ 0, 0 ]
             # Others:

--- a/Resources/Prototypes/_Scav/Catalog/Jukebox/Standard.yml
+++ b/Resources/Prototypes/_Scav/Catalog/Jukebox/Standard.yml
@@ -20,10 +20,10 @@
   id: Re_-Your-Brains
   name: "Re: Your Brains - Jonathan Coulton"
   path:
-    path: /Audio/_Scav/Jukebox/The-Future-Soon.ogg
+    path: /Audio/_Scav/Jukebox/Re_-Your-Brains.ogg
 
 - type: jukebox
   id: The-Future-Soon
   name: The Future Soon - Jonathan Coulton
   path:
-    path: /Audio/_Scav/Jukebox/Re_-Your-Brains.ogg
+    path: /Audio/_Scav/Jukebox/The-Future-Soon.ogg

--- a/Resources/Prototypes/_Scav/Entities/Mobs/Species/yinglet.yml
+++ b/Resources/Prototypes/_Scav/Entities/Mobs/Species/yinglet.yml
@@ -87,7 +87,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 200
+        damage: 300
       behaviors:
       - !type:GibBehavior { }
     # - trigger: # Scav: removed to match frontier's handling of


### PR DESCRIPTION
## About the PR
Fixed mislabeled JoCo songs
Increased Gib threshold for Yinglets
updated default CCVars
changed observe warning since respawning is allowed
made brigmedic and detective available without sherrif opening them

## Why / Balance
Various balance changes and requested server-specific tweaks and fixes

## Technical details
config changes, yaml, flavortext

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
:cl:
- tweak; fixed swapped labels on JoCo songs
- tweak: increased gib threshold for yinglets
- tweak: changed default ccvars for respawn time, shuttle resale rate, and away site air extraction
- tweak: changed observe flavortext
- tweak: made brigmedic and detective start with an open slot