### PR TITLE
Ported "Make VendingMachineInventoryEntry a data definition for post-init savegrid" from Wizden

### DIFF
--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -250,15 +250,18 @@ namespace Content.Shared.VendingMachines
         // End Frontier: taxes, cash slot
     }
 
-    [Serializable, NetSerializable]
-    public sealed class VendingMachineInventoryEntry
+    [Serializable, NetSerializable, DataDefinition]
+    public sealed partial class VendingMachineInventoryEntry
     {
-        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public InventoryType Type;
-        [ViewVariables(VVAccess.ReadWrite)]
+
+        [DataField]
         public string ID;
-        [ViewVariables(VVAccess.ReadWrite)]
+
+        [DataField]
         public uint Amount;
+
         public VendingMachineInventoryEntry(InventoryType type, string id, uint amount)
         {
             Type = type;


### PR DESCRIPTION
## About the PR
Made VendingMachineInventoryEntry a data definition so it can be saved to disk. Ported from wizden at https://github.com/space-wizards/space-station-14/pull/38406

## Why / Balance
This was one of the major hiccups with persistent ships

## Technical details
Made VendingMachineInventoryEntry a data definition

## How to test
Try to save the Bookworm (or any ship with a vending machine) to the garage, observe that it doesnt throw a critical error

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- fix: Vending machines no longer cause ships to fail to save
