### PR TITLE
Additional Persistence Fixes

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -8,7 +8,7 @@ using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Examine;
-using Content.Server._Scav.Persistence;
+using Content.Shared._Scav.Persistence;
 
 namespace Content.Server.DeviceNetwork.Systems
 {
@@ -46,7 +46,7 @@ namespace Content.Server.DeviceNetwork.Systems
             SubscribeLocalEvent<DeviceNetworkComponent, ComponentShutdown>(OnNetworkShutdown);
             SubscribeLocalEvent<DeviceNetworkComponent, ExaminedEvent>(OnExamine);
             SubscribeLocalEvent<DeviceNetworkComponent, GridReInitEvent>(OnGridReInit);
-            
+
             _activeQueue = _queueA;
             _nextQueue = _queueB;
         }

--- a/Content.Server/Power/EntitySystems/PowerChargeSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerChargeSystem.cs
@@ -1,4 +1,4 @@
-using Content.Server._Scav.Persistence;
+using Content.Shared._Scav.Persistence;
 using Content.Server.Administration.Logs;
 using Content.Server.Audio;
 using Content.Server.Emp;

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -33,7 +33,7 @@ using Content.Shared.Preferences;
 using Content.Server.Shuttles.Components;
 using Content.Server._NF.Station.Components;
 using System.Text.RegularExpressions;
-using Content.Server._Scav.Persistence;
+using Content.Shared._Scav.Persistence;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Access;

--- a/Content.Server/_Scav/Persistence/ShuttlePersistenceSystem.cs
+++ b/Content.Server/_Scav/Persistence/ShuttlePersistenceSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._Scav.Persistence;
+
 namespace Content.Server._Scav.Persistence;
 
 public sealed partial class ShuttlePersistenceSystem : EntitySystem
@@ -26,15 +28,7 @@ public sealed partial class ShuttlePersistenceSystem : EntitySystem
             }
 
             var ev = new GridReInitEvent(); //this is a LOT of variable declarations because its inside a recursive loop, was it better to define it once?
-            RaiseLocalEvent(uid, ev);
+            RaiseLocalEvent(uid, ref ev);
         }
-    }
-}
-
-
-public sealed class GridReInitEvent : EntityEventArgs
-{
-    public GridReInitEvent()
-    {
     }
 }

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -34,7 +34,7 @@ using Content.Server.Shuttles.Systems;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Utility;
 using Content.Server._NF.ShuttleRecords;
-using Content.Server._Scav.Persistence;
+using Content.Shared._Scav.Persistence;
 using Content.Server.Access.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._Scav.Persistence; // Scav
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Stacks;
@@ -37,6 +38,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         SubscribeLocalEvent<MaterialStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MaterialStorageComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<MaterialStorageComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
+        SubscribeLocalEvent<MaterialStorageComponent, GridReInitEvent>(OnGridReInit); // Scav
     }
 
     public override void Update(float frameTime)
@@ -57,6 +59,13 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
     {
         _appearance.SetData(uid, MaterialStorageVisuals.Inserting, false);
     }
+
+    // Scav
+    private void OnGridReInit(EntityUid uid, MaterialStorageComponent component, GridReInitEvent args)
+    {
+        _appearance.SetData(uid, MaterialStorageVisuals.Inserting, false);
+    }
+    // End Scav
 
     /// <summary>
     /// Gets all the materials stored on this entity

--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
+using Content.Shared._Scav.Persistence;
 
 namespace Content.Shared.Timing;
 
@@ -19,6 +20,7 @@ public sealed class UseDelaySystem : EntitySystem
         SubscribeLocalEvent<UseDelayComponent, EntityUnpausedEvent>(OnUnpaused);
         SubscribeLocalEvent<UseDelayComponent, ComponentGetState>(OnDelayGetState);
         SubscribeLocalEvent<UseDelayComponent, ComponentHandleState>(OnDelayHandleState);
+        SubscribeLocalEvent<UseDelayComponent, GridReInitEvent>(OnGridReInit);
     }
 
     private void OnDelayHandleState(Entity<UseDelayComponent> ent, ref ComponentHandleState args)
@@ -186,5 +188,10 @@ public sealed class UseDelaySystem : EntitySystem
             entry.EndTime = curTime - _metadata.GetPauseTime(ent) + entry.Length;
         }
         Dirty(ent);
+    }
+
+    private void OnGridReInit(Entity<UseDelayComponent> ent, ref GridReInitEvent args)
+    {
+        ResetAllDelays(ent);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Shared._Scav.Persistence;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -101,6 +102,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         SubscribeLocalEvent<GunComponent, CycleModeEvent>(OnCycleMode);
         SubscribeLocalEvent<GunComponent, HandSelectedEvent>(OnGunSelected);
         SubscribeLocalEvent<GunComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<GunComponent, GridReInitEvent>(OnGridReInit);
     }
 
     private void OnMapInit(Entity<GunComponent> gun, ref MapInitEvent args)
@@ -623,6 +625,11 @@ public abstract partial class SharedGunSystem : EntitySystem
             comp.ProjectileSpeedModified = ev.ProjectileSpeed;
             DirtyField(gun, nameof(GunComponent.ProjectileSpeedModified));
         }
+    }
+
+    private void OnGridReInit(EntityUid uid, GunComponent component, ref GridReInitEvent args)
+    {
+        RefreshModifiers(uid);
     }
 
     protected abstract void CreateEffect(EntityUid gunUid, MuzzleFlashEvent message, EntityUid? user = null);

--- a/Content.Shared/_Scav/Persistence/SharedShuttlePersistenceSystem.cs
+++ b/Content.Shared/_Scav/Persistence/SharedShuttlePersistenceSystem.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._Scav.Persistence;
+
+[ByRefEvent]
+public record struct GridReInitEvent();

--- a/Content.Shared/_Scav/Persistence/ShuttlePersistenceTrackerComponent.cs
+++ b/Content.Shared/_Scav/Persistence/ShuttlePersistenceTrackerComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server._Scav.Persistence;
+namespace Content.Shared._Scav.Persistence;
 
 /// <summary>
 /// Used to track the ShipId of a ship spawned from a garage console. Due to EntitySerializer not liking Guids, the Guid is stored as a string here.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed broken interact timers on toolbelts, boxes, etc. Fixed pistols not shooting. Fixed autolathes not rendering correctly.

## Why / Balance
Bugfixes of things broken by persistence

## Technical details
Restructured ShuttlePersistenceSystem, GridReInitEvent and ShuttlePersistenceTrackerComponent are now in shared namespace instead of server, reworked existing references to reflect this. Also, changed GridReInitEvent  to be a ByRefEvent struct instead of a class.
Added GridReInitEvent subscriptions on UseDelaySystem, SharedGunSystem, and SharedMaterialStorageSystem

## How to test
Retrieve a ship from the garage, particularly one from before the update. Observe that utility belts and pistols work properly, and lathes render correctly now.

## Media
<img width="507" height="821" alt="image" src="https://github.com/user-attachments/assets/42179605-c527-4b7a-ae27-7ad8125e39b2" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
GridReInitEvent and ShuttlePersistenceTrackerComponent are now in shared namespace instead of server

**Changelog**
:cl:
- fix: Fixed broken containers after server rebuild
- fix: Fixed broken pistols/weapons
- fix: Fixed buggy lathe sprites
