### PR TITLE
Even more persistence fixes

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -16,7 +16,8 @@ using Content.Shared.Labels.Components;
 using Content.Shared.Chemistry.Reagent; // Frontier
 using Content.Shared.Verbs; // Frontier
 using Content.Shared.Examine; // Frontier
-using Content.Server.Construction; // Frontier
+using Content.Server.Construction;
+using Content.Shared._Scav.Persistence; // Frontier
 using Content.Shared.Labels.EntitySystems; // Frontier
 
 namespace Content.Server.Chemistry.EntitySystems
@@ -58,6 +59,8 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserClearContainerSolutionMessage>(OnClearContainerSolutionMessage);
 
             SubscribeLocalEvent<ReagentDispenserComponent, MapInitEvent>(OnMapInit, before: new []{typeof(ItemSlotsSystem)});
+
+            SubscribeLocalEvent<ReagentDispenserComponent, GridReInitEvent>(OnGridReInit);
         }
 
         private void SubscribeUpdateUiState<T>(Entity<ReagentDispenserComponent> ent, ref T ev)
@@ -286,6 +289,16 @@ namespace Content.Server.Chemistry.EntitySystems
                 }
             }
             // End Frontier
+        }
+
+        private void OnGridReInit(EntityUid uid, ReagentDispenserComponent component, GridReInitEvent args)
+        {
+            _itemSlotsSystem.AddItemSlot(uid, SharedReagentDispenser.OutputSlotName, component.BeakerSlot);
+
+            for (int i = 0; i < component.StorageSlots.Count; i++)
+            {
+                _itemSlotsSystem.AddItemSlot(uid, component.StorageSlotIds[i], component.StorageSlots[i]);
+            }
         }
 
         // Frontier: upgradable parts

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Scav.Persistence;
 using Content.Shared.Storage.Components; // Frontier: Server<Shared
 using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
@@ -40,6 +41,7 @@ public sealed class MagnetPickupSystem : EntitySystem
         SubscribeLocalEvent<MagnetPickupComponent, MapInitEvent>(OnMagnetMapInit);
         SubscribeLocalEvent<MagnetPickupComponent, ExaminedEvent>(OnExamined); // Frontier
         SubscribeLocalEvent<MagnetPickupComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleMagnetVerb); // Frontier
+        SubscribeLocalEvent<MagnetPickupComponent, GridReInitEvent>(OnGridReInit);
     }
 
     private void OnMagnetMapInit(EntityUid uid, MagnetPickupComponent component, MapInitEvent args)
@@ -47,6 +49,10 @@ public sealed class MagnetPickupSystem : EntitySystem
         component.NextScan = _timing.CurTime;
     }
 
+    private void OnGridReInit(EntityUid uid, MagnetPickupComponent component, GridReInitEvent args)
+    {
+        component.NextScan = _timing.CurTime;
+    }
 
     // Frontier: togglable magnets
     private void AddToggleMagnetVerb(EntityUid uid, MagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/smartfridge.yml
@@ -88,6 +88,8 @@
   - type: AccessReader
   - type: ExplosionResistance
     damageCoefficient: 0.6
+  - type: ShipyardSellCondition # Scav
+    preserveOnSale: true # Scav
 
 - type: entity
   parent: DVSmartFridge

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/Crates/emergency_pod.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/Crates/emergency_pod.yml
@@ -101,3 +101,5 @@
     node: medicalpod
     containers:
     - entity_storage
+  - type: ShipyardSellCondition # Scav
+    preserveOnSale: true # Scav


### PR DESCRIPTION
## About the PR
Fixed reagent dispensers (chemistry and bar) for persistent ships
Fixed magnet pickup not working after recompile
Smart Fridges and medical bounty pods now get teleported off the ship instead of saving

## Why / Balance
Mostly bugfixes and dodging bugs

## Technical details
AddItemSlot needed to be called for the item slots on ReagentDispenserComponent, the data is saved in the component but the item slots are created in real time
Magnet pickup internal timer needed to be reset on grid reinit
Smart Fridges make ships unable to save until upstream changes make it down and Medical bounty pods break on save due to containing bodies, added ShipyardSellCondition component to both

## How to test
Save and load a ship, confirm that reagent dispensers, ore boxes work, and that smart fridges and medical pods teleport off

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
:cl:
- fix: Fixed reagent dispensers on persistent ships
- fix: Fixed ore boxes, etc breaking on persistent ships
- fix: Smart fridges now teleport off ships on sale to prevent them from breaking saves
- fix: Medical bounty pods now teleport off ships on sale