### PR TITLE
Shipyard/Garage console now teleports off any entities marked as nonsaveable

### DIFF
--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -302,7 +302,9 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     // checks if something has the ShipyardPreserveOnSaleComponent and if it does, adds it to the list
     private void FindEntitiesToPreserve(EntityUid entity, ref List<EntityUid> output)
     {
-        if (TryComp<ShipyardSellConditionComponent>(entity, out var comp) && comp.PreserveOnSale == true)
+        if (TryComp<ShipyardSellConditionComponent>(entity, out var comp) && comp.PreserveOnSale == true
+            || ((TryComp(entity, out MetaDataComponent? meta) && meta.EntityPrototype?.MapSavable == false)  // Scav: teleport anything not map-savable off the ship
+                && (TryComp(entity, out TransformComponent? xform) && xform.GridTraversal))) // Scav: dont know if we need to check this too but just to be safe
         {
             output.Add(entity);
             return;


### PR DESCRIPTION
## About the PR
Shipyard/Garage console now teleports off any entities marked as nonsaveable

## Why / Balance
The majority of save failures are due to mobs existing on the ship inside containers etc. This fixes that.

## Technical details
Adds check for EntityPrototype.MapSavable == false in ShipyardSystem.FindEntitiesToPreserve

## How to test
Try to save a ship with mobs aboard, observe that they get teleported to the console

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
This is a very broad check for any prototype marked as not MapSavable. At present this is mostly mobs (and some effects like the pointing arrows, etc.). If some new prototype is added that is marked as mapsavable but shouldnt be teleported like this, it could cause issues.

**Changelog**
:cl:
- tweak: Shipyard/Garage consoles now teleport mobs off of the ship when saving