### PR TITLE
End-of-round saving

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -315,6 +315,10 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
         var adminSys = _entityManager.SystemOrNull<AdminSystem>();
         var logMessage = message;
 
+        // Scav: Moved this check outside the foreach loop. Extreme logs should still chat-notify even if there are no attached players
+        if (impact == LogImpact.Extreme) // Always chat-notify Extreme logs
+            adminLog = true;
+
         foreach (var id in players)
         {
             var player = new AdminLogPlayer
@@ -341,9 +345,6 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
 
             if (adminLog)
                 continue;
-
-            if (impact == LogImpact.Extreme) // Always chat-notify Extreme logs
-                adminLog = true;
 
             if (impact == LogImpact.High) // Only chat-notify High logs if the player is below a threshold playtime
             {

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -302,7 +302,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
     // checks if something has the ShipyardPreserveOnSaleComponent and if it does, adds it to the list
     private void FindEntitiesToPreserve(EntityUid entity, ref List<EntityUid> output)
     {
-        if (TryComp<ShipyardSellConditionComponent>(entity, out var comp) && comp.PreserveOnSale == true
+        if (TryComp<ShipyardSellConditionComponent>(entity, out var comp) && (comp.PreserveOnSale || comp.BlockSale) // Scav: components that would normally block sale also get teleported. this check comes after that check in most cases that arent forcing the sale so its fine
             || ((TryComp(entity, out MetaDataComponent? meta) && meta.EntityPrototype?.MapSavable == false)  // Scav: teleport anything not map-savable off the ship
                 && (TryComp(entity, out TransformComponent? xform) && xform.GridTraversal))) // Scav: dont know if we need to check this too but just to be safe
         {

--- a/Content.Server/_Scav/Commands/GarageSaveCommand.cs
+++ b/Content.Server/_Scav/Commands/GarageSaveCommand.cs
@@ -7,9 +7,10 @@ using Robust.Shared.Console;
 namespace Content.Server._Scav.Commands;
 
 [AdminCommand(AdminFlags.Admin)]
-public sealed class GarageSave : LocalizedCommands
+public sealed class GarageSave : LocalizedEntityCommands
 {
     [Dependency] private readonly IEntityManager _ent = default!;
+    [Dependency] private readonly GarageSystem _garage = default!;
 
     public override string Command => "garagesave";
 
@@ -38,7 +39,7 @@ public sealed class GarageSave : LocalizedCommands
 
         if (_ent.TryGetComponent<ShuttlePersistenceTrackerComponent>(uid, out var persistence) && !String.IsNullOrEmpty(persistence.ShipGuid))
         {
-            bool saveSuccess = _ent.System<GarageSystem>().TryStoreShip(uid, persistence);
+            bool saveSuccess = _garage.TryStoreShip(uid, persistence);
             if(saveSuccess)
             {
                 shell.WriteLine("Save successful.");

--- a/Content.Server/_Scav/Commands/GarageSaveCommand.cs
+++ b/Content.Server/_Scav/Commands/GarageSaveCommand.cs
@@ -1,0 +1,56 @@
+using Content.Server._Scav.Shipyard.Systems;
+using Content.Server.Administration;
+using Content.Shared._Scav.Persistence;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._Scav.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class GarageSave : LocalizedCommands
+{
+    [Dependency] private readonly IEntityManager _ent = default!;
+
+    public override string Command => "garagesave";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError("Wrong number of arguments.");
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var uidNet))
+        {
+            shell.WriteError("Not a valid entity ID.");
+            return;
+        }
+
+        var uid = _ent.GetEntity(uidNet);
+
+        // no saving default grid
+        if (!_ent.EntityExists(uid))
+        {
+            shell.WriteError("That grid does not exist.");
+            return;
+        }
+
+        if (_ent.TryGetComponent<ShuttlePersistenceTrackerComponent>(uid, out var persistence) && !String.IsNullOrEmpty(persistence.ShipGuid))
+        {
+            bool saveSuccess = _ent.System<GarageSystem>().TryStoreShip(uid, persistence);
+            if(saveSuccess)
+            {
+                shell.WriteLine("Save successful.");
+            }
+            else
+            {
+                shell.WriteError("Save unsuccessful!");
+            }
+        }
+        else
+        {
+            shell.WriteError("Grid is not marked as a persistent ship.");
+        }
+    }
+}

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -192,8 +192,6 @@ public sealed partial class GarageSystem : SharedGarageSystem
             }
         }
 
-        var voucherUsed = HasComp<ShipyardVoucherComponent>(targetId);
-
         var fullName = deed != null ? ShipyardSystem.GetFullName(deed) : null;
 
         RefreshState(uid, fullName, targetId, (GarageConsoleUiKey)args.UiKey, player);
@@ -244,12 +242,49 @@ public sealed partial class GarageSystem : SharedGarageSystem
 
     private void StoreAllShips()
     {
+        List<EntityUid?> persistentShips = new List<EntityUid?>();
+
         var persistenceTrackerQuery = EntityQueryEnumerator<ShuttlePersistenceTrackerComponent>();
         while (persistenceTrackerQuery.MoveNext(out var shuttleUid, out var persistence))
         {
             TryStoreShip(shuttleUid, persistence);
+            persistentShips.Add(shuttleUid);
         }
 
+        var garageConsoleQuery = EntityQueryEnumerator<GarageConsoleComponent>();
+        while (garageConsoleQuery.MoveNext(out var consoleUid, out var component))
+        {
+            var targetId = component.TargetIdSlot.ContainerSlot?.ContainedEntity;
+
+            if (TryComp<ShuttleDeedComponent>(targetId, out var deed))
+            {
+                if (Deleted(deed!.ShuttleUid) || (deed!.ShuttleUid != null && persistentShips.Contains(deed.ShuttleUid))) //since entities might be queued for deletion but not yet deleted, need to check the list as well
+                {
+                    RemComp<ShuttleDeedComponent>(targetId!.Value);
+                    deed = null;
+                }
+            }
+
+            var fullName = deed != null ? ShipyardSystem.GetFullName(deed) : null;
+
+            if (!TryComp<ActivatableUIComponent>(consoleUid, out var uiComp) || uiComp.Key == null)
+                return;
+
+            var uiUsers = _ui.GetActors(consoleUid, uiComp.Key);
+
+            foreach (var user in uiUsers)
+            {
+                if (user is not { Valid: true } player)
+                    continue;
+
+                RefreshState(consoleUid,
+                    fullName,
+                    targetId,
+                    (GarageConsoleUiKey)uiComp.Key,
+                    player);
+
+            }
+        }
     }
 
     public bool TryStoreShip(EntityUid shuttleUid, ShuttlePersistenceTrackerComponent persistence)

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -38,6 +38,7 @@ using Content.Shared._Scav.Persistence;
 using Content.Server.Access.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
+using Content.Server.GameTicking;
 using Content.Server.Maps;
 using Content.Server.Preferences.Managers;
 using Content.Server.Radio.EntitySystems;
@@ -93,6 +94,7 @@ public sealed partial class GarageSystem : SharedGarageSystem
         SubscribeLocalEvent<GarageConsoleComponent, GarageConsoleRetrieveMessage>(OnRetrieveMessage);
         SubscribeLocalEvent<GarageConsoleComponent, EntInsertedIntoContainerMessage>(OnItemSlotChanged);
         SubscribeLocalEvent<GarageConsoleComponent, EntRemovedFromContainerMessage>(OnItemSlotChanged);
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
 
         RefreshShips();
     }
@@ -100,6 +102,24 @@ public sealed partial class GarageSystem : SharedGarageSystem
     private async void RefreshShips()
     {
         Ships = await _db.GetShipData();
+    }
+
+    private void OnRunLevelChanged(GameRunLevelChangedEvent args)
+    {
+        switch (args.New)
+        {
+            case GameRunLevel.PostRound:
+                SaveAllShips();
+                break;
+            case GameRunLevel.PreRoundLobby:
+                RefreshShips();
+                break;
+        }
+    }
+
+    private void SaveAllShips()
+    {
+
     }
 
     private void RefreshState(EntityUid uid, string? shipDeed, EntityUid? targetId, GarageConsoleUiKey uiKey, EntityUid player)

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -244,31 +244,75 @@ public sealed partial class GarageSystem : SharedGarageSystem
 
     private void StoreAllShips()
     {
-        /*
-        var persistenceTrackerQuery = EntityQueryEnumerator<ShuttlePersistenceTrackerComponent>();
-        while (persistenceTrackerQuery.MoveNext(out var shuttleUid, out var persistenceTracker))
-        {
-            //station records?
-            //get name and netent?
 
-            //finddisableshipyardsaleobjects equivalent
+        var persistenceTrackerQuery = EntityQueryEnumerator<ShuttlePersistenceTrackerComponent>();
+        while (persistenceTrackerQuery.MoveNext(out var shuttleUid, out var persistence))
+        {
+            //station records? probably best practice but we dont know what station to transfer to and the round is ending so it doesnt really matter anyway
+
+            var shuttleName = ToPrettyString(shuttleUid);
+            var shuttleNetEntity = _entityManager.GetNetEntity(shuttleUid);
+
+            //finddisableshipyardsaleobjects (actually no, i just made clean warp those objects too (wont affect other cases since the disable failstate happens first))
 
             //presaleshuttlecheck equivalent
+            if (!HasComp<ShuttleComponent>(shuttleUid)
+                || !TryComp(shuttleUid, out TransformComponent? xform))
+            {
+                _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Autosave for shuttle grid {ToPrettyString(shuttleUid)} as ship {persistence.ShipGuid} failed: shuttle is invalid. Admin intervention is necessary.");
+                continue;
+            }
+            //presaleshuttlecheck normally checks for organics at this stage, but that only checks for the presence of a Mind. player species and ghosts still get done by clean so just relying on that
+
+            if (TryGetNearestWarp(shuttleUid, out var warp))
+            {
+                _shipyardSystem.CleanGrid(shuttleUid, warp.Value); //this wants a uid to tp everything to
+            }
+            //else, teleport it somewhere else? idk
 
             if (_station.GetOwningStation(shuttleUid) is { Valid: true } shuttleStationUid)
             {
                 _station.DeleteStation(shuttleStationUid);
             }
 
-            _shipyardSystem.CleanGrid(shuttleUid, uid); //this wants a uid to tp everything to
-
             _docking.UndockDocks(shuttleUid);
             RemComp<IFFComponent>(shuttleUid);
             RemComp<NavMapComponent>(shuttleUid);
             RemComp<ShuttleDeedComponent>(shuttleUid);
             RemComp<StationMemberComponent>(shuttleUid);
+
+            if (!String.IsNullOrEmpty(persistence.ShipGuid))
+            {
+                var existingShipId = new Guid(persistence.ShipGuid);
+                var shipCacheIndex = Ships.FindIndex(s => s.ShipId == existingShipId);
+
+                var name = Ships[shipCacheIndex].ShipName;
+                var suffix = Ships[shipCacheIndex].ShipNameSuffix;
+
+                var filePath = "/ships/" + name + "_" + suffix + "_" + persistence.ShipGuid + ".yml";
+
+                var saveResult = _mapLoader.TrySaveGrid(shuttleUid, new ResPath(filePath));
+                if (!saveResult)
+                {
+                    _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Autosave for shuttle grid {ToPrettyString(shuttleUid)} as ship {persistence.ShipGuid} failed. Admin intervention is necessary.");
+                    continue;
+                }
+
+                Ships[shipCacheIndex] = new ShipData { ShipId = existingShipId, ShipName = name, ShipNameSuffix = suffix, FilePath = filePath, ProfileData = Ships[shipCacheIndex].ProfileData, Active = false};
+                _db.UpdateShip(existingShipId, name, suffix, filePath);
+
+                _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Medium, $"Ship {shuttleName} autosaved to the garage");
+            }
+
+            QueueDel(shuttleUid);
+
+            _shuttleRecordsSystem.RefreshStateForAll(true);
+            _shuttleRecordsSystem.TrySetSaleTime(shuttleNetEntity);
+            //also how do we handle existing deeds to prevent it from failing
+
+            //also, might want to do something with active menus, maybe disable them?
         }
-        */
+
     }
 
     public void OnStoreMessage(EntityUid uid, GarageConsoleComponent component, GarageConsoleStoreMessage args)
@@ -355,7 +399,7 @@ public sealed partial class GarageSystem : SharedGarageSystem
             _station.DeleteStation(shuttleStationUid);
         }
 
-        _shipyardSystem.CleanGrid(shuttleUid, TryGetNearestWarp(uid, out var warp) ? warp!.Value : uid);
+        _shipyardSystem.CleanGrid(shuttleUid, TryGetNearestWarp(uid, out var warp) ? warp.Value : uid);
 
         var name = deed.ShuttleName;
         var suffix = deed.ShuttleNameSuffix;

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared._Scav._Shipyard;
 using Content.Server._NF.Shipyard.Systems;
@@ -55,6 +56,7 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Preferences;
 using Content.Shared.Radio;
 using Content.Shared.StationRecords;
+using Content.Shared.Warps;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -82,6 +84,7 @@ public sealed partial class GarageSystem : SharedGarageSystem
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly AccessSystem _accessSystem = default!;
     [Dependency] private readonly StationRecordsSystem _records = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public List<ShipData> Ships = new List<ShipData>(); //local copy of the ships stored in the database, to avoid database async annoyances. Also tracks the current guid of active ships
 
@@ -99,6 +102,33 @@ public sealed partial class GarageSystem : SharedGarageSystem
         RefreshShips();
     }
 
+    private bool TryGetNearestWarp(EntityUid uid, [NotNullWhen(true)] out EntityUid? warp)
+    {
+        warp = null;
+        float? distance = null;
+        var warpQuery = EntityQueryEnumerator<GarageTeleportMarkerComponent>();
+        TryComp(uid, out TransformComponent? callerTransform);
+        while (warpQuery.MoveNext(out var warpUid, out var warpComponent))
+        {
+            if (TryComp(warpUid, out TransformComponent? warpTransform))
+            {
+                var newDistance = (_transform.GetMapCoordinates(warpTransform).Position - _transform.GetMapCoordinates(callerTransform!).Position).Length();
+                if (distance == null || newDistance < distance)
+                {
+                    warp = warpUid;
+                    distance = newDistance;
+                }
+            }
+        }
+
+        if (warp is null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     private async void RefreshShips()
     {
         Ships = await _db.GetShipData();
@@ -109,17 +139,12 @@ public sealed partial class GarageSystem : SharedGarageSystem
         switch (args.New)
         {
             case GameRunLevel.PostRound:
-                SaveAllShips();
+                StoreAllShips();
                 break;
             case GameRunLevel.PreRoundLobby:
                 RefreshShips();
                 break;
         }
-    }
-
-    private void SaveAllShips()
-    {
-
     }
 
     private void RefreshState(EntityUid uid, string? shipDeed, EntityUid? targetId, GarageConsoleUiKey uiKey, EntityUid player)
@@ -217,6 +242,35 @@ public sealed partial class GarageSystem : SharedGarageSystem
         }
     }
 
+    private void StoreAllShips()
+    {
+        /*
+        var persistenceTrackerQuery = EntityQueryEnumerator<ShuttlePersistenceTrackerComponent>();
+        while (persistenceTrackerQuery.MoveNext(out var shuttleUid, out var persistenceTracker))
+        {
+            //station records?
+            //get name and netent?
+
+            //finddisableshipyardsaleobjects equivalent
+
+            //presaleshuttlecheck equivalent
+
+            if (_station.GetOwningStation(shuttleUid) is { Valid: true } shuttleStationUid)
+            {
+                _station.DeleteStation(shuttleStationUid);
+            }
+
+            _shipyardSystem.CleanGrid(shuttleUid, uid); //this wants a uid to tp everything to
+
+            _docking.UndockDocks(shuttleUid);
+            RemComp<IFFComponent>(shuttleUid);
+            RemComp<NavMapComponent>(shuttleUid);
+            RemComp<ShuttleDeedComponent>(shuttleUid);
+            RemComp<StationMemberComponent>(shuttleUid);
+        }
+        */
+    }
+
     public void OnStoreMessage(EntityUid uid, GarageConsoleComponent component, GarageConsoleStoreMessage args)
     {
         if (args.Actor is not { Valid: true } player)
@@ -301,7 +355,7 @@ public sealed partial class GarageSystem : SharedGarageSystem
             _station.DeleteStation(shuttleStationUid);
         }
 
-        _shipyardSystem.CleanGrid(shuttleUid, uid);
+        _shipyardSystem.CleanGrid(shuttleUid, TryGetNearestWarp(uid, out var warp) ? warp!.Value : uid);
 
         var name = deed.ShuttleName;
         var suffix = deed.ShuttleNameSuffix;

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -244,75 +244,88 @@ public sealed partial class GarageSystem : SharedGarageSystem
 
     private void StoreAllShips()
     {
-
         var persistenceTrackerQuery = EntityQueryEnumerator<ShuttlePersistenceTrackerComponent>();
         while (persistenceTrackerQuery.MoveNext(out var shuttleUid, out var persistence))
         {
-            //station records? probably best practice but we dont know what station to transfer to and the round is ending so it doesnt really matter anyway
-
-            var shuttleName = ToPrettyString(shuttleUid);
-            var shuttleNetEntity = _entityManager.GetNetEntity(shuttleUid);
-
-            //finddisableshipyardsaleobjects (actually no, i just made clean warp those objects too (wont affect other cases since the disable failstate happens first))
-
-            //presaleshuttlecheck equivalent
-            if (!HasComp<ShuttleComponent>(shuttleUid)
-                || !TryComp(shuttleUid, out TransformComponent? xform))
-            {
-                _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Autosave for shuttle grid {ToPrettyString(shuttleUid)} as ship {persistence.ShipGuid} failed: shuttle is invalid. Admin intervention is necessary.");
-                continue;
-            }
-            //presaleshuttlecheck normally checks for organics at this stage, but that only checks for the presence of a Mind. player species and ghosts still get done by clean so just relying on that
-
-            if (TryGetNearestWarp(shuttleUid, out var warp))
-            {
-                _shipyardSystem.CleanGrid(shuttleUid, warp.Value); //this wants a uid to tp everything to
-            }
-            //else, teleport it somewhere else? idk
-
-            if (_station.GetOwningStation(shuttleUid) is { Valid: true } shuttleStationUid)
-            {
-                _station.DeleteStation(shuttleStationUid);
-            }
-
-            _docking.UndockDocks(shuttleUid);
-            RemComp<IFFComponent>(shuttleUid);
-            RemComp<NavMapComponent>(shuttleUid);
-            RemComp<ShuttleDeedComponent>(shuttleUid);
-            RemComp<StationMemberComponent>(shuttleUid);
-
-            if (!String.IsNullOrEmpty(persistence.ShipGuid))
-            {
-                var existingShipId = new Guid(persistence.ShipGuid);
-                var shipCacheIndex = Ships.FindIndex(s => s.ShipId == existingShipId);
-
-                var name = Ships[shipCacheIndex].ShipName;
-                var suffix = Ships[shipCacheIndex].ShipNameSuffix;
-
-                var filePath = "/ships/" + name + "_" + suffix + "_" + persistence.ShipGuid + ".yml";
-
-                var saveResult = _mapLoader.TrySaveGrid(shuttleUid, new ResPath(filePath));
-                if (!saveResult)
-                {
-                    _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Autosave for shuttle grid {ToPrettyString(shuttleUid)} as ship {persistence.ShipGuid} failed. Admin intervention is necessary.");
-                    continue;
-                }
-
-                Ships[shipCacheIndex] = new ShipData { ShipId = existingShipId, ShipName = name, ShipNameSuffix = suffix, FilePath = filePath, ProfileData = Ships[shipCacheIndex].ProfileData, Active = false};
-                _db.UpdateShip(existingShipId, name, suffix, filePath);
-
-                _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Medium, $"Ship {shuttleName} autosaved to the garage");
-            }
-
-            QueueDel(shuttleUid);
-
-            _shuttleRecordsSystem.RefreshStateForAll(true);
-            _shuttleRecordsSystem.TrySetSaleTime(shuttleNetEntity);
-            //also how do we handle existing deeds to prevent it from failing
-
-            //also, might want to do something with active menus, maybe disable them?
+            TryStoreShip(shuttleUid, persistence);
         }
 
+    }
+
+    public bool TryStoreShip(EntityUid shuttleUid, ShuttlePersistenceTrackerComponent persistence)
+    {
+        if (String.IsNullOrEmpty(persistence.ShipGuid))
+        {
+            return false;
+        }
+        //station records? probably best practice but we dont know what station to transfer to
+
+        var shuttleName = ToPrettyString(shuttleUid);
+        var shuttleNetEntity = _entityManager.GetNetEntity(shuttleUid);
+
+        //this check already exists in presaleshuttlecheck, but need to repeat here to be safe
+        if (!HasComp<ShuttleComponent>(shuttleUid)
+            || !TryComp(shuttleUid, out TransformComponent? xform))
+        {
+            _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Save for shuttle grid {ToPrettyString(shuttleUid)} as ship {persistence.ShipGuid} failed: shuttle is invalid. Admin intervention is necessary.");
+            return false;
+        }
+        //presaleshuttlecheck also normally checks for organics at this stage, but they get teleported off by Clean if that check is skipped anyway.
+
+        if (TryGetNearestWarp(shuttleUid, out var warp))
+        {
+            _shipyardSystem.CleanGrid(shuttleUid, warp.Value);
+        }
+        else
+        {
+            _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Save for shuttle grid {ToPrettyString(shuttleUid)} failed because no garage clean warp points exist");
+            return false;
+        }
+
+        //checks are complete, start taking destructive actions
+        if (_station.GetOwningStation(shuttleUid) is { Valid: true } shuttleStationUid)
+        {
+            _station.DeleteStation(shuttleStationUid);
+        }
+
+        _docking.UndockDocks(shuttleUid);
+        RemComp<IFFComponent>(shuttleUid);
+        RemComp<NavMapComponent>(shuttleUid);
+        RemComp<ShuttleDeedComponent>(shuttleUid);
+        RemComp<StationMemberComponent>(shuttleUid);
+
+        if (!String.IsNullOrEmpty(persistence.ShipGuid))
+        {
+            var existingShipId = new Guid(persistence.ShipGuid);
+            var shipCacheIndex = Ships.FindIndex(s => s.ShipId == existingShipId);
+
+            var name = Ships[shipCacheIndex].ShipName;
+            var suffix = Ships[shipCacheIndex].ShipNameSuffix;
+
+            var filePath = "/ships/" + name + "_" + suffix + "_" + persistence.ShipGuid + ".yml";
+
+            var saveResult = _mapLoader.TrySaveGrid(shuttleUid, new ResPath(filePath));
+            if (!saveResult)
+            {
+                _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"Save for shuttle grid {ToPrettyString(shuttleUid)} as ship {persistence.ShipGuid} failed. Admin intervention is necessary.");
+                return false;
+            }
+
+            Ships[shipCacheIndex] = new ShipData { ShipId = existingShipId, ShipName = name, ShipNameSuffix = suffix, FilePath = filePath, ProfileData = Ships[shipCacheIndex].ProfileData, Active = false};
+            _db.UpdateShip(existingShipId, name, suffix, filePath);
+
+            _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Medium, $"Ship {shuttleName} saved to the garage");
+        }
+
+        QueueDel(shuttleUid);
+
+        _shuttleRecordsSystem.RefreshStateForAll(true);
+        _shuttleRecordsSystem.TrySetSaleTime(shuttleNetEntity);
+
+        //will existing deeds be a problem? in testing it seems like it wipes them automatically
+
+        //also, might want to do something with active menus, maybe disable them?
+        return true;
     }
 
     public void OnStoreMessage(EntityUid uid, GarageConsoleComponent component, GarageConsoleStoreMessage args)

--- a/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
+++ b/Content.Server/_Scav/Shipyard/Systems/GarageSystem.cs
@@ -424,13 +424,13 @@ public sealed partial class GarageSystem : SharedGarageSystem
                 if (!saveResult)
                 {
                     ConsolePopup(player, Loc.GetString("garage-console-save-error")); //suffice it to say, if this happens, thats catastrophically bad, we've already deleted a bunch of stuff...
-                    _adminLogger.Add(LogType.ShipYardUsage, LogImpact.High, $"{ToPrettyString(player):actor} failed to save shuttle grid {ToPrettyString(shuttleUid)} as existing ship {persistence.ShipGuid} via {ToPrettyString(uid)}. Admin intervention is likely necessary.");
+                    _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"{ToPrettyString(player):actor} failed to save shuttle grid {ToPrettyString(shuttleUid)} as existing ship {persistence.ShipGuid} via {ToPrettyString(uid)}. Admin intervention is likely necessary.");
                     PlayDenySound(player, uid, component);
                     return;
                 }
 
                 var i = Ships.FindIndex(s => s.ShipId == existingShipId);
-                Ships[i] = new ShipData { ShipId = existingShipId, ShipName = name, ShipNameSuffix = suffix, FilePath = filePath, ProfileData = new List<ProfileIdentifier> { new ProfileIdentifier { UserId = userId!.Value.UserId, Slot = slot!.Value } }, Active = false};
+                Ships[i] = new ShipData { ShipId = existingShipId, ShipName = name, ShipNameSuffix = suffix, FilePath = filePath, ProfileData = Ships[i].ProfileData, Active = false};
                 _db.UpdateShip(existingShipId, name, suffix, filePath);
 
                 SendStoreMessage(uid, deed.ShuttleOwner, name + " " + suffix, component.ShipyardChannel, player);
@@ -445,7 +445,7 @@ public sealed partial class GarageSystem : SharedGarageSystem
                 if (!saveResult)
                 {
                     ConsolePopup(player, Loc.GetString("garage-console-save-error")); //suffice it to say, if this happens, thats catastrophically bad, we've already deleted a bunch of stuff...
-                    _adminLogger.Add(LogType.ShipYardUsage, LogImpact.High, $"{ToPrettyString(player):actor} failed to save shuttle grid {ToPrettyString(shuttleUid)} via {ToPrettyString(uid)}. Admin intervention is likely necessary.");
+                    _adminLogger.Add(LogType.ShipYardUsage, LogImpact.Extreme, $"{ToPrettyString(player):actor} failed to save shuttle grid {ToPrettyString(shuttleUid)} via {ToPrettyString(uid)}. Admin intervention is likely necessary.");
                     PlayDenySound(player, uid, component);
                     return;
                 }

--- a/Content.Shared/_Scav/Shipyard/Components/GarageTeleportMarkerComponent.cs
+++ b/Content.Shared/_Scav/Shipyard/Components/GarageTeleportMarkerComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Scav.Shipyard.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class GarageTeleportMarkerComponent : Component
+{
+
+}

--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 08/22/2025 03:51:55
-  entityCount: 5521
+  time: 09/09/2025 16:19:42
+  entityCount: 5522
 maps:
 - 5691
 grids:
@@ -18336,6 +18336,13 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: GarageTeleportMarker
+  entities:
+  - uid: 2317
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2173
 - proto: GasMixerOn
   entities:
   - uid: 1124

--- a/Resources/Maps/_NF/POI/trade.yml
+++ b/Resources/Maps/_NF/POI/trade.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 08/22/2025 03:55:40
-  entityCount: 6475
+  time: 09/09/2025 16:16:13
+  entityCount: 6479
 maps: []
 grids:
 - 1
@@ -3753,7 +3753,7 @@ entities:
       pos: 39.5,-1.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -5614.6533
+      secondsUntilStateChange: -5699.575
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14743,6 +14743,28 @@ entities:
     components:
     - type: Transform
       pos: 55.343708,-18.591537
+      parent: 1
+- proto: GarageTeleportMarker
+  entities:
+  - uid: 6476
+    components:
+    - type: Transform
+      pos: -23.5,2.5
+      parent: 1
+  - uid: 6477
+    components:
+    - type: Transform
+      pos: 14.5,-17.5
+      parent: 1
+  - uid: 6478
+    components:
+    - type: Transform
+      pos: 56.5,21.5
+      parent: 1
+  - uid: 6479
+    components:
+    - type: Transform
+      pos: 80.5,-0.5
       parent: 1
 - proto: GasAnalyzer
   entities:

--- a/Resources/Maps/_NF/POI/trademall.yml
+++ b/Resources/Maps/_NF/POI/trademall.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 08/22/2025 04:04:55
-  entityCount: 6318
+  time: 09/09/2025 16:17:30
+  entityCount: 6321
 maps: []
 grids:
 - 1
@@ -22987,6 +22987,23 @@ entities:
     components:
     - type: Transform
       pos: 29.514894,10.760558
+      parent: 1
+- proto: GarageTeleportMarker
+  entities:
+  - uid: 6319
+    components:
+    - type: Transform
+      pos: 50.5,12.5
+      parent: 1
+  - uid: 6320
+    components:
+    - type: Transform
+      pos: 62.5,0.5
+      parent: 1
+  - uid: 6321
+    components:
+    - type: Transform
+      pos: 50.5,-11.5
       parent: 1
 - proto: GasMixerOn
   entities:

--- a/Resources/Prototypes/_Scav/Entities/Markers/warp_point.yml
+++ b/Resources/Prototypes/_Scav/Entities/Markers/warp_point.yml
@@ -1,0 +1,8 @@
+- type: entity
+  id: GarageTeleportMarker
+  parent: MarkerBase
+  name: garage clean warp
+  components:
+  - type: GarageTeleportMarker
+  - type: Sprite
+    state: pink


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added end-of-round autosaving for persistent ships, and a command to save persistence ships manually. Also, fixed the local garage cache getting its state stuck between rounds preventing unsaved ships from retrieving, and storing someone else's ship incorrectly assigning it to you.

## Why / Balance
End-of-round autosaves will help prevent loss of ship progress, and prevent savescumming
Command will help admins more easily resolve error situations

## Technical details
Added new marker, GarageTeleportMarker. This is used as a destination when teleporting bad items off of ships instead of teleporting directly to the console entity. Helper function GarageSystem.TryFindNearestWarp will find the nearest warp to a given object, and return false if it doesnt exist.
Updated Frontier Outpost, Trade Outpost, and Trademall to have these markers
Added subscription to OnRunLevelChanged in GarageSystem.
- If the new state is preroundlobby, refreshes the cache. This will repair any errors and ensure the active state is not preserved between rounds
- If the new state is postround, calls StoreAllShips
New GarageSystem function StoreAllShips and helper function TryStoreShip
- StoreAllShips calls TryStoreShip for all entities with ShuttlePersistenceTrackerComponent, then refreshes the state of all garage consoles.
- TryStoreShip is a simplified copy of the code from OnStoreMessage, with only the functions and checks needed to save and none of the limitations and checks specific to a player doing it with a console. In the future, OnStoreMessage should probably be updated to use this to cut down on repetition
Added new "garagesave" command, takes a grid uid and calls GarageSystem.TryStoreShip
GarageSystem.OnStoreMessage no longer overwrites owners in cache to the user using the ui, instead just leaves it as the value it was before.
ShipyardSystem.FindEntitiesToPreserve now also teleports objects normally marked to block sale outright. With normal sell/store that failstate is checked first, so shouldnt cause any problems, but we want to teleport those if the save is being forced.
Promoted existing save failure events to extreme instead of high so they always get reported in chat
Changed AdminLogManager to report extreme logs in chat, even if no user is tied to the event (since the events generated in the end of round function arent user-tied). Please note that these logs will still only be viewable in the admin log window if you specifically check the box to show userless logs.

## How to test
End the round, observe that all active persistent ships either save or notify admins that the save failed.
Observe that the garagesave command lets you do this individually for specific ships
Try storing someone else's persistence ship and note that it doesnt add it to your own garage instead
Observe that ships left out at end of round dont become unretrievable next round

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added end-of-round autosave for persistent ships
- add: Added admin command to save persistent ships without requiring a console or docking the ship
- add: Added new warp points to Frontier Outpost, Trade Outpost, and Trademall, which will be used to warp problem objects off ships when saving (players will also be warped here at end-of-round autosave)
- fix: Storing someone else's persistent ship will no longer put it in your garage instead
- fix: Leaving a ship unstored at the end of a round will no longer make it permanently unretrievable