### PR TITLE
Expeditionremoval

### DIFF
--- a/Resources/Locale/en-US/_NF/shipyard/shipyard-console-component.ftl
+++ b/Resources/Locale/en-US/_NF/shipyard/shipyard-console-component.ftl
@@ -53,6 +53,7 @@ shipyard-console-class-Chemistry = Chemistry
 shipyard-console-class-Botany = Botany
 shipyard-console-class-Engineering = Engineering
 shipyard-console-class-Atmospherics = Atmospherics
+shipyard-console-class-Mercenary = Mercenary
 shipyard-console-class-Medical = Medical
 shipyard-console-class-Civilian = Civilian
 shipyard-console-class-Kitchen = Kitchen

--- a/Resources/Prototypes/_NF/PointsOfInterest/lodge.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/lodge.yml
@@ -8,20 +8,20 @@
 
 # Notes:
 # Provides higher end expeditionary ships and a space for vets to spawn in away from potential frontier shenanigans
-- type: pointOfInterest
-  id: Lodge
-  parent: BasePOI
-  name: 'Expeditionary Lodge'
-  minimumDistance: 1650
-  maximumDistance: 3400
-  spawnGroup: Required
-  gridPath: /Maps/_NF/POI/lodge.yml
-  addComponents:
-  - type: IFF
-    color: "#3737F8"
-  - type: StationTransit
-    routes:
-      SpawnPoints: 20
+#- type: pointOfInterest
+#  id: Lodge
+#  parent: BasePOI
+#  name: 'Expeditionary Lodge'
+#  minimumDistance: 1650
+#  maximumDistance: 3400
+#  spawnGroup: Required
+#  gridPath: /Maps/_NF/POI/lodge.yml
+#  addComponents:
+#  - type: IFF
+#    color: "#3737F8"
+#  - type: StationTransit
+#    routes:
+#      SpawnPoints: 20
 
 - type: gameMap
   id: Lodge

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/anchor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/anchor.yml
@@ -12,14 +12,13 @@
   id: Anchor
   parent: BaseVessel
   name: KC Anchor
-  description: A large luxury cruiser capable of long ranged travel acrossed the sector, expedition capable.
+  description: A large luxury cruiser capable of long ranged travel acrossed the sector.
   price: 140000 # $108432 after appraisal +30ish% (~32000)
   category: Large
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/anchor.yml
   guidebookPage: Null
   class:
-  - Expedition
   - Civilian
   engine:
   - AME
@@ -31,7 +30,7 @@
   minPlayers: 0
   stations:
     Anchor:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Anchor {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/anchor.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/anchor.yml
@@ -15,11 +15,11 @@
   description: A large luxury cruiser capable of long ranged travel acrossed the sector.
   price: 140000 # $108432 after appraisal +30ish% (~32000)
   category: Large
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/anchor.yml
   guidebookPage: Null
   class:
-  - Civilian
+  - Civilian # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Anchor:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Anchor {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
@@ -15,11 +15,11 @@
   description: Civilian conversion of an old military light frigate from the early days of humanity's expansion to the stars, predating FTL technology. Manufactured by Langstad-Voigt Heavy Industries.
   price: 56200 # ~48800$ on mapinit + ~7320$ from 15% markup
   category: Medium
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/brigand.yml
   guidebookPage: ShipyardBrigand
   class:
-  - Mercenary
+  - Mercenary # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Brigand:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Brigand {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/brigand.yml
@@ -15,11 +15,11 @@
   description: Civilian conversion of an old military light frigate from the early days of humanity's expansion to the stars, predating FTL technology. Manufactured by Langstad-Voigt Heavy Industries.
   price: 56200 # ~48800$ on mapinit + ~7320$ from 15% markup
   category: Medium
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/brigand.yml
   guidebookPage: ShipyardBrigand
   class:
-  - Expedition
+  - Mercenary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Brigand:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Brigand {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/charon.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/charon.yml
@@ -19,11 +19,11 @@
   # 627 total tiles
   # In light of the mid-range tile count and relatively narrow width I feel like Medium is more appropriate than Large even though it is technically one tile too long for the class.
   category: Medium
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/charon.yml
   guidebookPage: ShipyardCharon
   class:
-  - Expedition
+  - Cargo
   engine:
   - AME
 
@@ -32,9 +32,9 @@
   mapName: 'Charon'
   mapPath: /Maps/_NF/Shuttles/Expedition/charon.yml
   minPlayers: 0
-  stations: 
+  stations:
     Charon:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Charon {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/charon.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/charon.yml
@@ -19,11 +19,11 @@
   # 627 total tiles
   # In light of the mid-range tile count and relatively narrow width I feel like Medium is more appropriate than Large even though it is technically one tile too long for the class.
   category: Medium
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/charon.yml
   guidebookPage: ShipyardCharon
   class:
-  - Cargo
+  - Cargo # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -34,7 +34,7 @@
   minPlayers: 0
   stations:
     Charon:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Charon {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/decadedove.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/decadedove.yml
@@ -7,19 +7,19 @@
 # Discord: ???
 
 # Shuttle Notes:
-# 
+#
 - type: vessel
   id: DecadeDove
   parent: BaseVessel
   name: DYS Dove
-  description: Versatile expedition-capable multi-purpose light freighter.
+  description: Versatile multi-purpose light freighter.
   price: 78500 # ~60100$ on mapinit + ~18000$ from 30% markup
   category: Medium
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/decadedove.yml
   guidebookPage: Null
   class:
-  - Expedition
+  - Cargo
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     DecadeDove:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Dove {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/decadedove.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/decadedove.yml
@@ -15,11 +15,11 @@
   description: Versatile multi-purpose light freighter.
   price: 78500 # ~60100$ on mapinit + ~18000$ from 30% markup
   category: Medium
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/decadedove.yml
   guidebookPage: Null
   class:
-  - Cargo
+  - Cargo # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     DecadeDove:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Dove {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
@@ -15,11 +15,11 @@
   description: Highly modular salvaging vessel welded together from smaller re-purposed hulls.
   price: 81000 # ~62075$ on mapinit + ~18650$ from 30% markup
   category: Medium
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/dragonfly.yml
   guidebookPage: Null
   class:
-  - Salvage
+  - Salvage # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Dragonfly:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Dragonfly {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/dragonfly.yml
@@ -7,7 +7,7 @@
 # Discord: ???
 
 # Shuttle Notes:
-# 
+#
 - type: vessel
   id: Dragonfly
   parent: BaseVessel
@@ -15,11 +15,11 @@
   description: Highly modular salvaging vessel welded together from smaller re-purposed hulls.
   price: 81000 # ~62075$ on mapinit + ~18650$ from 30% markup
   category: Medium
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/dragonfly.yml
   guidebookPage: Null
   class:
-  - Expedition
+  - Salvage
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Dragonfly:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Dragonfly {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/pathfinder.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/pathfinder.yml
@@ -12,14 +12,14 @@
   id: Pathfinder
   parent: BaseVessel
   name: KC Pathfinder
-  description: Once a scout ship serving with the Nanotrasen Marine Expeditionary Forces, this now decommissioned expedition capable ship can be yours!
+  description: Once a scout ship serving with the Nanotrasen Marine Expeditionary Forces, this now decommissioned ship can be yours!
   price: 52920
   category: Small
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/pathfinder.yml
   guidebookPage: ShipyardPathfinder
   class:
-  - Expedition
+  - Fighter
   engine:
   - AME
 
@@ -28,9 +28,9 @@
   mapName: 'KC Pathfinder'
   mapPath: /Maps/_NF/Shuttles/Expedition/pathfinder.yml
   minPlayers: 0
-  stations: 
+  stations:
     Pathfinder:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Pathfinder {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/pathfinder.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/pathfinder.yml
@@ -15,11 +15,11 @@
   description: Once a scout ship serving with the Nanotrasen Marine Expeditionary Forces, this now decommissioned ship can be yours!
   price: 52920
   category: Small
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/pathfinder.yml
   guidebookPage: ShipyardPathfinder
   class:
-  - Fighter
+  - Fighter # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Pathfinder:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Pathfinder {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/sprinter.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/sprinter.yml
@@ -12,14 +12,14 @@
   id: Sprinter
   parent: BaseVessel
   name: KC Sprinter
-  description: A light freighter often picked by bounty hunters due to its quick acceleration, expedition capable.
+  description: A light freighter often picked by bounty hunters due to its quick acceleration.
   price: 56800 # ~$43700 on mapinit plus ~30% markup
   category: Medium
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/sprinter.yml
   guidebookPage: Null
   class:
-  - Expedition
+  - Mercenary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Sprinter:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Sprinter {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Expedition/sprinter.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Expedition/sprinter.yml
@@ -15,11 +15,11 @@
   description: A light freighter often picked by bounty hunters due to its quick acceleration.
   price: 56800 # ~$43700 on mapinit plus ~30% markup
   category: Medium
-  group: Shipyard
+  group: Shipyard # Scav: moved to normal shipyard
   shuttlePath: /Maps/_NF/Shuttles/Expedition/sprinter.yml
   guidebookPage: Null
   class:
-  - Mercenary
+  - Mercenary # Scav: no longer expeditionary
   engine:
   - AME
 
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Sprinter:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Sprinter {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Nfsd/wasp.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Nfsd/wasp.yml
@@ -2,7 +2,7 @@
   id: Wasp
   parent: BaseVessel
   name: NSF Wasp
-  description: A large expedition oriented ship for holding prisoners and making them work planetside.
+  description: A large capital ship for holding prisoners and making them work planetside.
   price: 135000
   category: Large
   group: Security
@@ -12,7 +12,6 @@
   class:
   - Capital
   - Detainment
-  - Expedition
   engine:
   - AME
 
@@ -23,7 +22,7 @@
   minPlayers: 0
   stations:
     Wasp:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Wasp {1}'

--- a/Resources/Prototypes/_NF/Shipyard/Nfsd/wasp.yml
+++ b/Resources/Prototypes/_NF/Shipyard/Nfsd/wasp.yml
@@ -12,6 +12,7 @@
   class:
   - Capital
   - Detainment
+  # Scav: no longer expedition
   engine:
   - AME
 
@@ -22,7 +23,7 @@
   minPlayers: 0
   stations:
     Wasp:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Wasp {1}'

--- a/Resources/Prototypes/_NF/Shipyard/kestrel.yml
+++ b/Resources/Prototypes/_NF/Shipyard/kestrel.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Kestrel:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierVessel # Scav: no longer expeditionary, dunno why it still was tbh
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Kestrel {1}'

--- a/Resources/Prototypes/_NF/Shipyard/kestrel.yml
+++ b/Resources/Prototypes/_NF/Shipyard/kestrel.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Kestrel:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Kestrel {1}'
@@ -41,4 +41,4 @@
           availableJobs:
             ContractorInterview: [ 0, 0 ]
             PilotInterview: [ 0, 0 ]
-            MercenaryInterview: [ 0, 0 ]  
+            MercenaryInterview: [ 0, 0 ]

--- a/Resources/Prototypes/_Scav/Shipyard/bee.yml
+++ b/Resources/Prototypes/_Scav/Shipyard/bee.yml
@@ -2,15 +2,14 @@
   id: Bee
   parent: BaseVessel
   name: IMS Bee
-  description: Small expedition-capable landing and salvage craft.
+  description: Small landing and salvage craft.
   price: 25000
   category: Small
-  group: Expedition
+  group: Shipyard
   shuttlePath: /Maps/_Scav/Shuttles/bee.yml
   guidebookPage: Null
   class:
   - Salvage
-  - Expedition
   engine:
   - Uranium
 
@@ -21,7 +20,7 @@
   minPlayers: 0
   stations:
     Bee:
-      stationProto: StandardFrontierExpeditionVessel
+      stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Bee {1}'

--- a/Resources/Prototypes/_Scav/Shipyard/persistentShipTemplate.yml
+++ b/Resources/Prototypes/_Scav/Shipyard/persistentShipTemplate.yml
@@ -2,6 +2,7 @@
   id: PersistentShipTemplate
   parent: BaseVessel
   name: Ship
+  group: Custom # This will prevent it from showing up in the default shipyard
   description: "Template for ship saved to the garage. This message should not appear."
   shuttlePath: /Maps/_Scav/Shuttles/template.yml
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made all expedition ships normal shipyard ships
Expedition consoles are now disabled on former expedition ships
Removed expeditionary lodge
Persistent ship template no longer displays in shipyard

## Why / Balance
Expeditions were broken with persistence, dont want to focus on them.

## Technical details
Changed vessel prototypes for expedition ships to be classed as other types than expedition and be in the normal Shipyard category, and no longer make reference to expedition capability
Changed GameMap prototypes for expedition ships to use StandardFrontierVessel instead of StandardFrontierExpeditionVessel
Added location string for Mercenary class of ship
Commented out POI definition for expeditionary lodge.
Moved persistent ship template ship to "custom" shipyard so it no longer shows up as purchasable in the normal console

## How to test
Use the normal shipyard console, observe that you can buy expedition ships and their expedition consoles don't provide expeditions anymore

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing properly breaking, but removal of lodge POI is notable in case something tries to reference it

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Expeditionary Lodge no longer spawns
- tweak: Former expedition ships are now available from standard console
- remove: Expedition console disabled
- fix: Persistent ship template no longer displays in shipyard